### PR TITLE
formating of the yang

### DIFF
--- a/ietf-optical-impairment-topology.tree
+++ b/ietf-optical-impairment-topology.tree
@@ -13,9 +13,9 @@ module: ietf-optical-impairment-topology
        |     +--ro nominal-power-spectral-density?   decimal64
        +--ro media-channel-group* [i]
        |  +--ro i                 int16
-       |  +--ro media-channels* [flex-n]
-       |     +--ro flex-n       uint16
-       |     +--ro flex-m?      uint16
+       |  +--ro media-channels* [flexi-n]
+       |     +--ro flexi-n      uint16
+       |     +--ro flexi-m?     uint16
        |     +--ro OTSiG-ref?   -> /nw:networks/network/node/tet:te/tunnel-termination-point/OTSiG-element/OTSiG-identifier
        |     +--ro OTSi-ref?    -> /nw:networks/network/node/tet:te/tunnel-termination-point/OTSiG-element[OTSiG-identifier=current()/../OTSiG-ref]/OTSiG-container/OTSi/OTSi-carrier-id
        +--ro OMS-elements* [elt-index]

--- a/ietf-optical-impairment-topology.yang
+++ b/ietf-optical-impairment-topology.yang
@@ -1,29 +1,23 @@
-module ietf-optical-impairment-topology {  
+module ietf-optical-impairment-topology {
   yang-version 1.1;
-
   namespace "urn:ietf:params:xml:ns:yang:ietf-optical-impairment-topology";
-
-  prefix "optical-imp-topo";
+  prefix optical-imp-topo;
 
   import ietf-network {
-    prefix "nw";
+    prefix nw;
   }
-
   import ietf-network-topology {
-    prefix "nt";
+    prefix nt;
   }
-
   import ietf-te-topology {
-    prefix "tet";
+    prefix tet;
   }
-
   import ietf-layer0-types {
-    prefix "layer0-types"; 
+    prefix layer0-types;
   }
 
   organization
     "IETF CCAMP Working Group";
-
   contact
     "Editor:   Young Lee  <leeyoung@huawei.com>
      Editor:   Haomian Zheng <zhenghaomian@huawei.com>
@@ -33,9 +27,7 @@ module ietf-optical-impairment-topology {
      Editor:   Auge Jean-Luc <jeanluc.auge@orange.com>
      Editor:   Le Rouzic Esther <esther.lerouzic@orange.com>
      Editor:   Julien Meuric <julien.meuric@orange.com>
-     Editor:   Italo Busi <Italo.Busi@huawei.com>"; 
-
-
+     Editor:   Italo Busi <Italo.Busi@huawei.com>";
   description
     "This module contains a collection of YANG definitions for
      impairment-aware optical networks.
@@ -44,7 +36,7 @@ module ietf-optical-impairment-topology {
      authors of the code.  All rights reserved.
 
      Redistribution and use in source and binary forms, with or
-     without modification, is permitted pursuant to, and subject 
+     without modification, is permitted pursuant to, and subject
      to the license terms contained in, the Simplified BSD
      License set forth in Section 4.c of the IETF Trust's Legal
      Provisions Relating to IETF Documents
@@ -54,397 +46,396 @@ module ietf-optical-impairment-topology {
     description
       "Initial Version";
     reference
-      "RFC XXXX: A Yang Data Model for Impairment-aware 
+      "RFC XXXX: A Yang Data Model for Impairment-aware
        Optical Networks";
   }
 
   identity modulation {
-    description "base identity for modulation type"; 
+    description
+      "base identity for modulation type";
   }
-  
+
   identity QPSK {
     base modulation;
-    description 
+    description
       "QPSK (Quadrature Phase Shift Keying) modulation";
   }
 
   identity DP_QPSK {
     base modulation;
-    description 
+    description
       "DP-QPSK (Dual Polarization Quadrature
-       Phase Shift Keying) modulation"; 
+       Phase Shift Keying) modulation";
   }
+
   identity QAM8 {
-    base modulation;      
-    description 
+    base modulation;
+    description
       "8QAM (8-State Quadrature Amplitude Modulation) modulation";
   }
+
   identity QAM16 {
-    base modulation;      
-    description 
+    base modulation;
+    description
       "QAM16 (Quadrature Amplitude Modulation)";
   }
+
   identity DP_QAM8 {
     base modulation;
-    description 
+    description
       "DP-QAM8 (Dual Polarization Quadrature Amplitude Modulation)";
   }
+
   identity DC_DP_QAM8 {
-    base modulation;      
-    description 
+    base modulation;
+    description
       "DC DP-QAM8 (Dual Polarization Quadrature Amplitude Modulation)";
   }
+
   identity DP_QAM16 {
     base modulation;
-    description 
+    description
       "DP-QAM16 (Dual Polarization Quadrature Amplitude Modulation)";
   }
+
   identity DC_DP_QAM16 {
-    base modulation;      
-    description 
+    base modulation;
+    description
       "DC DP-QAM16 (Dual Polarization Quadrature Amplitude Modulation)";
   }
-    
 
   identity FEC {
-    description 
-      "Enumeration that defines the type of 
+    description
+      "Enumeration that defines the type of
        Forward Error Correction";
   }
+
   identity reed-solomon {
     base FEC;
-      description
-  "Reed-Solomon error correction";
+    description
+      "Reed-Solomon error correction";
   }
+
   identity hamming-code {
     base FEC;
-      description 
-  "Hamming Code error correction";
+    description
+      "Hamming Code error correction";
   }
+
   identity golay {
     base FEC;
-      description "Golay error correction";
+    description
+      "Golay error correction";
   }
-    
+
   typedef fiber-type {
     type enumeration {
-      enum G.652 { 
-      description "G.652 Standard Singlemode Fiber"; 
+      enum G.652 {
+        description
+          "G.652 Standard Singlemode Fiber";
       }
       enum G.654 {
-        description "G.654 Cutoff Shifted Fiber";
+        description
+          "G.654 Cutoff Shifted Fiber";
       }
       enum G.653 {
-        description "G.653 Dispersion Shifted Fiber";
+        description
+          "G.653 Dispersion Shifted Fiber";
       }
       enum G.655 {
-        description "G.655 Non-Zero Dispersion Shifted Fiber";
-      } 
+        description
+          "G.655 Non-Zero Dispersion Shifted Fiber";
+      }
       enum G.656 {
-        description "G.656 Non-Zero Dispersion for Wideband 
-               Optical Transport";
+        description
+          "G.656 Non-Zero Dispersion for Wideband
+           Optical Transport";
       }
       enum G.657 {
-        description "G.657 Bend-Insensitive Fiber"; 
+        description
+          "G.657 Bend-Insensitive Fiber";
       }
     }
-    description 
+    description
       "ITU-T based fiber-types";
-  }   
-  
+  }
+
   grouping transponder-attributes {
-    description "Configuration of an optical transponder";
-        
+    description
+      "Configuration of an optical transponder";
     leaf-list available-modulation {
       type identityref {
-      base modulation;
+        base modulation;
       }
-      config false;
-    description 
-      "List determining all the available modulations";
-    }
-
-    leaf modulation-type {
-      type identityref {
-      base modulation;
-      }
-    config false;
-      description 
-      "Modulation configured for the transponder";
-    }
-
-    leaf-list available-baud-rates { 
-      type uint32;
-      units Bd;
       config false;
       description
-        "list of available baud-rates. Baud-rate is the unit for 
-         symbol rate or modulation rate in symbols per second or 
-         pulses per second. It is the number of distinct symbol 
-         changes (signaling events) made to the transmission medium 
+        "List determining all the available modulations";
+    }
+    leaf modulation-type {
+      type identityref {
+        base modulation;
+      }
+      config false;
+      description
+        "Modulation configured for the transponder";
+    }
+    leaf-list available-baud-rates {
+      type uint32;
+      units "Bd";
+      config false;
+      description
+        "list of available baud-rates. Baud-rate is the unit for
+         symbol rate or modulation rate in symbols per second or
+         pulses per second. It is the number of distinct symbol
+         changes (signaling events) made to the transmission medium
          per second in a digitally modulated signal or a line code";
     }
-
     leaf configured-baud-rate {
       type uint32;
-      units Bd;
-    config false;
-      description "configured baud-rate";
+      units "Bd";
+      config false;
+      description
+        "configured baud-rate";
     }
-
     leaf-list available-FEC {
       type identityref {
-      base FEC;
+        base FEC;
       }
       config false;
-      description "List determining all the available FEC";
+      description
+        "List determining all the available FEC";
     }
-
     leaf FEC-type {
       type identityref {
-      base FEC;
+        base FEC;
       }
       config false;
-    description 
-      "FEC type configured for the transponder";
+      description
+        "FEC type configured for the transponder";
     }
-  
     leaf FEC-code-rate {
       type decimal64 {
-      fraction-digits 8;
-      range "0..max";
+        fraction-digits 8;
+        range "0..max";
       }
       config false;
-      description "FEC-code-rate";
+      description
+        "FEC-code-rate";
     }
-  
     leaf FEC-threshold {
       type decimal64 {
-      fraction-digits 8;
-      range "0..max";
+        fraction-digits 8;
+        range "0..max";
       }
       config false;
-    description 
+      description
         "Threshold on the BER, for which FEC is able to correct errors";
     }
-    
   }
-    
+
   grouping sliceable-transponder-attributes {
     description
       "Configuration of a sliceable transponder.";
     list transponder-list {
       key "carrier-id";
       config false;
-      description "List of carriers";
+      description
+        "List of carriers";
       leaf carrier-id {
         type uint32;
         config false;
-        description "Identifier of the carrier";
+        description
+          "Identifier of the carrier";
       }
-    }        
+    }
   }
 
   grouping optical-fiber-data {
-    description 
-    "optical link (fiber) attributes with impairment data";
+    description
+      "optical link (fiber) attributes with impairment data";
     leaf fiber-type {
       type fiber-type;
-      config false; 
-      description "fiber-type";
+      config false;
+      description
+        "fiber-type";
     }
-
     leaf span-length {
       type decimal64 {
         fraction-digits 2;
       }
       units "km";
       config false;
-      description "the lenght of the fiber span in km"; 
+      description
+        "the lenght of the fiber span in km";
     }
-   
     leaf input-power {
       type decimal64 {
         fraction-digits 2;
       }
       units "dBm";
-      config false; 
-      description 
-      "Average input power level estimated at the receiver 
-         of the link";
+      config false;
+      description
+        "Average input power level estimated at the receiver
+           of the link";
     }
-
     leaf output-power {
       type decimal64 {
         fraction-digits 2;
       }
       units "dBm";
-      description 
-      "Mean launched power at the transmitter of the link";
+      description
+        "Mean launched power at the transmitter of the link";
     }
-
     leaf pmd {
       type decimal64 {
         fraction-digits 8;
         range "0..max";
       }
       units "ps/(km)^0.5";
-      config false; 
-      description 
-      "Polarization Mode Dispersion";
+      config false;
+      description
+        "Polarization Mode Dispersion";
     }
-
     leaf cd {
       type decimal64 {
         fraction-digits 5;
       }
       units "ps/nm/km";
-      config false; 
-      description 
-      "Cromatic Dispersion";
+      config false;
+      description
+        "Cromatic Dispersion";
     }
-
     leaf osnr {
       type decimal64 {
         fraction-digits 5;
       }
       units "dB";
-      config false; 
-      description 
-      "Optical Signal-to-Noise Ratio (OSNR) estimated
-         at the receiver"; 
+      config false;
+      description
+        "Optical Signal-to-Noise Ratio (OSNR) estimated
+           at the receiver";
     }
-
     leaf sigma {
       type decimal64 {
         fraction-digits 5;
       }
       units "dB";
       config false;
-      description 
-      "sigma in the Gausian Noise Model";
+      description
+        "sigma in the Gausian Noise Model";
     }
   }
-  
+
   grouping optical-channel-data {
-  description 
-    "optical impairment data per channel/wavelength"; 
-  leaf bit-rate {
-    type decimal64 {
-      fraction-digits 8;
-        range "0..max";
-    }
-    units "Gbit/s";
-    config false;
-    description 
-      "Gross bit rate";
-  }
-    
-    leaf BER {
-    type decimal64 {
-      fraction-digits 18;
-            range "0..max";
-    }
-    config false;
-      description 
-      "BER (Bit Error Rate)";
-  }
-
-    leaf ch-input-power {
-          type decimal64 {
-           fraction-digits 2;
-        }
-        units "dBm";
-        config false; 
-        description 
-    "Per channel average input power level 
-          estimated at the receiver of the link";
-        }
-
-  leaf ch-pmd {
-    type decimal64 {
+    description
+      "optical impairment data per channel/wavelength";
+    leaf bit-rate {
+      type decimal64 {
         fraction-digits 8;
-      range "0..max";
+        range "0..max";
+      }
+      units "Gbit/s";
+      config false;
+      description
+        "Gross bit rate";
     }
-    units "ps/(km)^0.5";
-    config false; 
-    description 
-      "per channel Polarization Mode Dispersion";
-  }
-
-  leaf ch-cd {
-    type decimal64 {
-            fraction-digits 5;
+    leaf BER {
+      type decimal64 {
+        fraction-digits 18;
+        range "0..max";
+      }
+      config false;
+      description
+        "BER (Bit Error Rate)";
     }
-    units "ps/nm/km";
-    config false; 
-          description 
-      "per channel Cromatic Dispersion";
-  }
-
-  leaf ch-osnr {
-    type decimal64 {
-      fraction-digits 5;
+    leaf ch-input-power {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units "dBm";
+      config false;
+      description
+        "Per channel average input power level
+              estimated at the receiver of the link";
     }
+    leaf ch-pmd {
+      type decimal64 {
+        fraction-digits 8;
+        range "0..max";
+      }
+      units "ps/(km)^0.5";
+      config false;
+      description
+        "per channel Polarization Mode Dispersion";
+    }
+    leaf ch-cd {
+      type decimal64 {
+        fraction-digits 5;
+      }
+      units "ps/nm/km";
+      config false;
+      description
+        "per channel Cromatic Dispersion";
+    }
+    leaf ch-osnr {
+      type decimal64 {
+        fraction-digits 5;
+      }
       units "dB";
-    config false; 
-    description 
-      "per channel Optical Signal-to-Noise Ratio 
-            (OSNR) estimated at the receiver"; 
-        }
-
-    leaf q-factor {
-    type decimal64 {
-      fraction-digits 5;
+      config false;
+      description
+        "per channel Optical Signal-to-Noise Ratio
+              (OSNR) estimated at the receiver";
     }
-    units "dB";
-    config false; 
-      description 
-      "q-factor estimated at the receiver"; 
-  }
+    leaf q-factor {
+      type decimal64 {
+        fraction-digits 5;
+      }
+      units "dB";
+      config false;
+      description
+        "q-factor estimated at the receiver";
+    }
   }
 
   grouping standard_mode {
-    description 
+    description
       "ITU-T G.698.2 standard mode that guarantees interoperability.
        It must be an string with the following format:
        B-DScW-ytz(v) where all these attributes are conformant
        to the ITU-T recomendation";
-    
     leaf standard_mode {
       type layer0-types:standard-mode;
       config false;
-      description 
+      description
         "G.698.2 standard mode";
     }
   }
-  
+
   grouping organizational_mode {
-    description 
+    description
       "Transponder operational mode supported by organizations or
        vendor";
-    
     leaf operational-mode {
       type layer0-types:operational-mode;
       config false;
-      description 
-        "configured organization- or vendor-specific 
+      description
+        "configured organization- or vendor-specific
          application identifiers (AI) supported by the transponder";
     }
-        
     leaf organization-identifier {
       type layer0-types:vendor-identifier;
       config false;
-      description 
-      "organization identifier that uses organizational
-         mode"; 
-      
+      description
+        "organization identifier that uses organizational
+           mode";
     }
-  } 
-  
-    /*
+  }
+
+  /*
    * Identities
    */
+
   identity type-element {
     description
       "Base identity for element type";
@@ -473,7 +464,7 @@ module ietf-optical-impairment-topology {
     description
       "Concentratedloss element";
   }
-  
+
   identity type-power-mode {
     description
       "power equalization mode used within the OMS and its elements";
@@ -494,49 +485,57 @@ module ietf-optical-impairment-topology {
   /*
    * Groupings
    */
+
   grouping amplifier-params {
-    description "describes parameters for an amplifier";
-    container amplifier{
-    description "amplifier type, operatonal parameters are described"; 
+    description
+      "describes parameters for an amplifier";
+    container amplifier {
+      description
+        "amplifier type, operatonal parameters are described";
       leaf type_variety {
-        type string ;
-        mandatory true ;
-        description 
-          "String identifier of amplifier type referencing 
-          a specification in a separate equipment catalog";
+        type string;
+        mandatory true;
+        description
+          "String identifier of amplifier type referencing
+           a specification in a separate equipment catalog";
       }
       container operational {
-        description "amplifier operationnal parameters";
+        description
+          "amplifier operationnal parameters";
         leaf actual-gain {
           type decimal64 {
             fraction-digits 2;
           }
-          units dB ;
-      mandatory true ;
-          description "..";    
+          units "dB";
+          mandatory true;
+          description
+            "..";
         }
         leaf tilt-target {
           type decimal64 {
             fraction-digits 2;
           }
-          mandatory true ;
-          description "..";    
+          mandatory true;
+          description
+            "..";
         }
         leaf out-voa {
           type decimal64 {
             fraction-digits 2;
           }
-          units dB;
-      mandatory true;
-          description "..";    
+          units "dB";
+          mandatory true;
+          description
+            "..";
         }
         leaf in-voa {
           type decimal64 {
             fraction-digits 2;
           }
-          units dB;
-      mandatory true;
-          description "..";    
+          units "dB";
+          mandatory true;
+          description
+            "..";
         }
         uses power-param;
       }
@@ -544,122 +543,137 @@ module ietf-optical-impairment-topology {
   }
 
   grouping fiber-params {
-    description "String identifier of fiber type referencing a specification in a separate equipment catalog";
+    description
+      "String identifier of fiber type referencing a specification in a separate equipment catalog";
     container fiber {
-    description "fiber characteristics"; 
+      description
+        "fiber characteristics";
       leaf type_variety {
-        type string ;
-    mandatory true ;  
-        description "fiber type";
+        type string;
+        mandatory true;
+        description
+          "fiber type";
       }
       leaf length {
         type decimal64 {
           fraction-digits 2;
         }
-        units km;
-    mandatory true ;
-    description "length of fiber"; 
+        units "km";
+        mandatory true;
+        description
+          "length of fiber";
       }
       leaf loss_coef {
         type decimal64 {
           fraction-digits 2;
         }
-        units dB/km;
-    mandatory true ;
-    description "loss coefficient of the fiber"; 
+        units "dB/km";
+        mandatory true;
+        description
+          "loss coefficient of the fiber";
       }
       leaf total_loss {
         type decimal64 {
           fraction-digits 2;
         }
-        units dB;
-    mandatory true ;
-        description 
+        units "dB";
+        mandatory true;
+        description
           "includes all losses: fiber loss and conn_in and conn_out losses";
       }
-      leaf pmd{
+      leaf pmd {
         type decimal64 {
           fraction-digits 2;
         }
-        units sqrt(ps);
-    description "pmd of the fiber";
+        units "sqrt(ps)";
+        description
+          "pmd of the fiber";
       }
-      leaf conn_in{
+      leaf conn_in {
         type decimal64 {
           fraction-digits 2;
         }
-        units dB;
-    description "connector-in";
+        units "dB";
+        description
+          "connector-in";
       }
-      leaf conn_out{
+      leaf conn_out {
         type decimal64 {
           fraction-digits 2;
         }
-        units dB;
-    description "connector-out"; 
+        units "dB";
+        description
+          "connector-out";
       }
     }
   }
 
-  grouping roadm-params{
-    description "roadm parameters description";
-    container roadm{
-    description "roadm parameters";
+  grouping roadm-params {
+    description
+      "roadm parameters description";
+    container roadm {
+      description
+        "roadm parameters";
       leaf type_variety {
-        type string ;
-        mandatory true ;
-        description "String identifier of roadm type referencing a specification in a separate equipment catalog";
-      }      
+        type string;
+        mandatory true;
+        description
+          "String identifier of roadm type referencing a specification in a separate equipment catalog";
+      }
       leaf loss {
         type decimal64 {
           fraction-digits 2;
         }
-        units dB ;
-        description "..";        
+        units "dB";
+        description
+          "..";
       }
     }
   }
 
-  grouping concentratedloss-params{
-    description "concentrated loss";
-    container concentratedloss{
-    description "concentrated loss"; 
+  grouping concentratedloss-params {
+    description
+      "concentrated loss";
+    container concentratedloss {
+      description
+        "concentrated loss";
       leaf loss {
         type decimal64 {
           fraction-digits 2;
         }
-        units dB ;
-        description "..";        
+        units "dB";
+        description
+          "..";
       }
     }
   }
 
-  grouping power-param{
+  grouping power-param {
     description
       "optical power or PSD after the ROADM or after the out-voa";
     choice power-param {
       description
         "select the mode: channel power or power spectral density";
       case channel-power {
- /*       when "equalization-mode='channel-power'"; */
-        leaf nominal-channel-power{
+        /*       when "equalization-mode='channel-power'"; */
+        leaf nominal-channel-power {
           type decimal64 {
-              fraction-digits 1;
+            fraction-digits 1;
           }
-          units dBm ;
-          description 
+          units "dBm";
+          description
             " Reference channel power after the ROADM or after the out-voa. ";
         }
       }
-      case power-spectral-density{
- /*       when "equalization-mode='power-spectral-density'"; */
-        leaf nominal-power-spectral-density{
+      case power-spectral-density {
+        /*       when "equalization-mode='power-spectral-density'"; */
+        leaf nominal-power-spectral-density {
           type decimal64 {
-              fraction-digits 16;
+            fraction-digits 16;
           }
-          units W/Hz ;
-          description 
-            " Reference power spectral density after the ROADM or after the out-voa. 
+          units "W/Hz";
+          description
+            " Reference power spectral density after the ROADM or after the out-voa.
               Typical value : 3.9 E-14, resolution 0.1nW/MHz";
         }
       }
@@ -667,84 +681,91 @@ module ietf-optical-impairment-topology {
   }
 
   grouping oms-general-optical-params {
-    description "OMS link optical parameters";
+    description
+      "OMS link optical parameters";
     leaf generalized-snr {
       type decimal64 {
         fraction-digits 5;
       }
       units "dB@0.1nm";
-      description "generalized snr";
+      description
+        "generalized snr";
     }
-    leaf equalization-mode{
+    leaf equalization-mode {
       type identityref {
         base type-power-mode;
       }
       mandatory true;
-      description "equalization mode";    
+      description
+        "equalization mode";
     }
     uses power-param;
   }
 
   grouping OTSiG {
-    description "OTSiG definition , representing client digital information stream supported by 1 or more OTSi"; 
-    
+    description
+      "OTSiG definition , representing client digital information stream supported by 1 or more OTSi";
     container OTSiG-container {
       config false;
       description
-        "the container contains the related list of OTSi. 
-		 The list could also be of only 1 element";
-     list OTSi {
-       key "OTSi-carrier-id"; 
-       description 
-         "list of OTSi's under OTSi-G";
-       leaf OTSi-carrier-id {
-         type int16;
-         description "OTSi carrier-id";
-         }
-       leaf OTSi-carrier-frequency {
-         type decimal64 {
-           fraction-digits 3;
-         }
-         units GHz;
-         config false;
-         description 
-           "OTSi carrier frequency";
-       }
-       leaf OTSi-signal-width {
-         type decimal64 {
-           fraction-digits 3;
-         }
-         units GHz;
-         config false;
-         description 
-           "OTSi signal width";
-       }    
-       leaf channel-delta-power {
-         type decimal64 {
-           fraction-digits 2;
-         }
-         units dB;
-         config false;
-         description
-           "optional ; delta power to ref channel input-power applied 
-		    to this media channel";
-       } 
-  
-     } 
-    }  // OTSiG container 
-  } // OTSiG grouping  
-  
+        "the container contains the related list of OTSi.
+         The list could also be of only 1 element";
+      list OTSi {
+        key "OTSi-carrier-id";
+        description
+          "list of OTSi's under OTSi-G";
+        leaf OTSi-carrier-id {
+          type int16;
+          description
+            "OTSi carrier-id";
+        }
+        leaf OTSi-carrier-frequency {
+          type decimal64 {
+            fraction-digits 3;
+          }
+          units "GHz";
+          config false;
+          description
+            "OTSi carrier frequency";
+        }
+        leaf OTSi-signal-width {
+          type decimal64 {
+            fraction-digits 3;
+          }
+          units "GHz";
+          config false;
+          description
+            "OTSi signal width";
+        }
+        leaf channel-delta-power {
+          type decimal64 {
+            fraction-digits 2;
+          }
+          units "dB";
+          config false;
+          description
+            "optional ; delta power to ref channel input-power applied
+             to this media channel";
+        }
+      }
+    }
+    // OTSiG container 
+  }
+
+  // OTSiG grouping  
+
   grouping media-channel-groups {
-    description "media channel groups"; 
+    description
+      "media channel groups";
     list media-channel-group {
-    key "i"; 
-      description 
-        "list of media channel groups"; 
+      key "i";
+      description
+        "list of media channel groups";
       leaf i {
         type int16;
-          description "index of media channel group member";
-      }   
-  
+        description
+          "index of media channel group member";
+      }
       list media-channels {
         key "flexi-n";
         description
@@ -752,186 +773,190 @@ module ietf-optical-impairment-topology {
         uses layer0-types:flexi-grid-channel;
         leaf OTSiG-ref {
           type leafref {
-           path "/nw:networks/nw:network/nw:node/tet:te" +
-                "/tet:tunnel-termination-point/OTSiG-element/OTSiG-identifier" ;
-           
-          } 
-          description 
-             "Reference to the OTSiG list to get OTSiG identifier of the 
-              OSiG carried by this media channel that reports the transient stat";   
+            path "/nw:networks/nw:network/nw:node/tet:te"
+               + "/tet:tunnel-termination-point/OTSiG-element/OTSiG-identifier";
+          }
+          description
+            "Reference to the OTSiG list to get OTSiG identifier of the
+             OSiG carried by this media channel that reports the transient stat";
         }
         leaf OTSi-ref {
           type leafref {
-            path "/nw:networks/nw:network/nw:node/tet:te" +
-                "/tet:tunnel-termination-point/OTSiG-element[OTSiG-identifier=current()/../OTSiG-ref]/"+
-                "OTSiG-container/OTSi/OTSi-carrier-id" ;
+            path "/nw:networks/nw:network/nw:node/tet:te"
+               + "/tet:tunnel-termination-point/OTSiG-element[OTSiG-identifier=current()/../OTSiG-ref]/"
+               + "OTSiG-container/OTSi/OTSi-carrier-id";
           }
-          description 
-             "Reference to the OTSi list supporting the related OTSiG" ;
+          description
+            "Reference to the OTSi list supporting the related OTSiG";
         }
-        
+      }
+      // media channels list 
+    }
+    // media-channel-groups list 
+  }
 
-      } // media channels list 
-    } // media-channel-groups list 
-  } // media media-channel-groups grouping
-  
+  // media media-channel-groups grouping
+
   grouping oms-element {
-    description "OMS description";
+    description
+      "OMS description";
     list OMS-elements {
-        key "elt-index";
+      key "elt-index";
+      description
+        "defines the spans and the amplifier blocks of the amplified lines";
+      leaf elt-index {
+        type uint16;
         description
-          "defines the spans and the amplifier blocks of the amplified lines";
-        leaf elt-index {
-          type uint16;
-          description
-            "ordered list of Index of OMS element (whether it's a Fiber, an EDFA or a Concentratedloss)";
+          "ordered list of Index of OMS element (whether it's a Fiber, an EDFA or a Concentratedloss)";
+      }
+      leaf uid {
+        type string;
+        description
+          "unique id of the element if it exists";
+      }
+      leaf type {
+        type identityref {
+          base type-element;
         }
-        leaf uid {
-          type string;
+        mandatory true;
+        description
+          "element type";
+      }
+      container element {
+        description
+          "element of the list of elements of the OMS";
+        choice element {
           description
-            "unique id of the element if it exists";
-        }
-        leaf type {
-          type identityref {
-             base type-element;
+            "OMS element type";
+          case amplifier {
+            /*             when "type = 'Edfa'"; */
+            uses amplifier-params;
           }
-      mandatory true;    
-      description "element type";       
-        }
-        
-        container element {
-          description "element of the list of elements of the OMS";
-          choice element {
-        description "OMS element type";
-            case amplifier {
- /*             when "type = 'Edfa'"; */
-              uses amplifier-params ;
-            }
-            case fiber {
-/*              when "type = 'Fiber'"; */
-              uses fiber-params ;
-            }
-            case concentratedloss {
-/*             when "type = 'Concentratedloss'"; */
-              uses concentratedloss-params ;
-            }            
+          case fiber {
+            /*              when "type = 'Fiber'"; */
+            uses fiber-params;
+          }
+          case concentratedloss {
+            /*             when "type = 'Concentratedloss'"; */
+            uses concentratedloss-params;
           }
         }
+      }
     }
   }
 
-/* Data nodes */
+  /* Data nodes */
 
   augment "/nw:networks/nw:network/nw:network-types"
-   + "/tet:te-topology" {
-   description "optical-impairment topology augmented";
-   container optical-impairment-topology {
-     presence "indicates an impairment-aware topology of optical networks";
-     description
-     "Container to identify impairment-aware topology type";
-   }
+        + "/tet:te-topology" {
+    description
+      "optical-impairment topology augmented";
+    container optical-impairment-topology {
+      presence "indicates an impairment-aware topology of optical networks";
+      description
+        "Container to identify impairment-aware topology type";
+    }
   }
 
   augment "/nw:networks/nw:network/nt:link/tet:te"
-   + "/tet:te-link-attributes"   {
-   when "/nw:networks/nw:network/nw:network-types"
-    +"/tet:te-topology/optical-imp-topo:optical-impairment-topology" {
+        + "/tet:te-link-attributes" {
+    when '/nw:networks/nw:network/nw:network-types'
+       + '/tet:te-topology/optical-imp-topo:optical-impairment-topology' {
+      description
+        "This augment is only valid for Optical Impairment.";
+    }
     description
-      "This augment is only valid for Optical Impairment.";
-   }
-   description "Optical Link augmentation for impairment data.";
-   container OMS-attributes {
-       config false; 
-       description "OMS attributes";  
-     uses oms-general-optical-params;
-     uses media-channel-groups;
-     uses oms-element; 
-     }
+      "Optical Link augmentation for impairment data.";
+    container OMS-attributes {
+      config false;
+      description
+        "OMS attributes";
+      uses oms-general-optical-params;
+      uses media-channel-groups;
+      uses oms-element;
+    }
   }
 
   augment "/nw:networks/nw:network/nw:node/tet:te"
-   + "/tet:tunnel-termination-point" {
-   when "/nw:networks/nw:network/nw:network-types"
-    +"/tet:te-topology/optical-imp-topo:optical-impairment-topology" {
+        + "/tet:tunnel-termination-point" {
+    when '/nw:networks/nw:network/nw:network-types'
+       + '/tet:te-topology/optical-imp-topo:optical-impairment-topology' {
+      description
+        "This augment is only valid for Impairment with non-sliceable
+         transponder model";
+    }
     description
-      "This augment is only valid for Impairment with non-sliceable 
-       transponder model";
-   }
-   description 
-     "Tunnel termination point augmentation for non-sliceable 
-      transponder model.";
-
-     list OTSiG-element {
-         key "OTSiG-identifier";
-         config false;
-         description 
-		   "the list of possible OTSiG representing client digital stream";
-
-         leaf OTSiG-identifier {
-            type int16;
-             description "index of OTSiG element";
-         }   
-         uses OTSiG;
-     }
-
-     list transponders-list {
-         key "transponder-id";
-     config false;
-         description "list of transponders";
-         leaf transponder-id {
-       type uint32; 
-       description "transponder identifier";
-         }
-     
-         choice mode {
-             description "standard mode, organizational mode or explicit mode";
-           
-             case G.692.2 {
-               uses standard_mode; 
-             }  
-        
-             case organizational_mode {
-               uses organizational_mode; 
-             }          
-           
-             case explicit_mode {
-               uses transponder-attributes; 
-             }
-         }
-         
-         leaf power {
-           type int32;
-           units "dBm";
-           config false; 
-           description "per channel power";
-         }
-
-         leaf power-min {
-           type int32;
-           units "dBm";
-           config false; 
-           description "minimum power of the transponder";
-         }
-
-         leaf power-max {
-           type int32;
-           units "dBm";
-           config false; 
-           description "maximum power of the transponder";
-         }
-   }
+      "Tunnel termination point augmentation for non-sliceable
+       transponder model.";
+    list OTSiG-element {
+      key "OTSiG-identifier";
+      config false;
+      description
+        "the list of possible OTSiG representing client digital stream";
+      leaf OTSiG-identifier {
+        type int16;
+        description
+          "index of OTSiG element";
+      }
+      uses OTSiG;
+    }
+    list transponders-list {
+      key "transponder-id";
+      config false;
+      description
+        "list of transponders";
+      leaf transponder-id {
+        type uint32;
+        description
+          "transponder identifier";
+      }
+      choice mode {
+        description
+          "standard mode, organizational mode or explicit mode";
+        case G.692.2 {
+          uses standard_mode;
+        }
+        case organizational_mode {
+          uses organizational_mode;
+        }
+        case explicit_mode {
+          uses transponder-attributes;
+        }
+      }
+      leaf power {
+        type int32;
+        units "dBm";
+        config false;
+        description
+          "per channel power";
+      }
+      leaf power-min {
+        type int32;
+        units "dBm";
+        config false;
+        description
+          "minimum power of the transponder";
+      }
+      leaf power-max {
+        type int32;
+        units "dBm";
+        config false;
+        description
+          "maximum power of the transponder";
+      }
+    }
   }
 
   augment "/nw:networks/nw:network/nw:node/tet:te"
-   + "/tet:tunnel-termination-point" {
-   when "/nw:networks/nw:network/nw:network-types"
-    +"/tet:te-topology/optical-imp-topo:optical-impairment-topology" {
+        + "/tet:tunnel-termination-point" {
+    when '/nw:networks/nw:network/nw:network-types'
+       + '/tet:te-topology/optical-imp-topo:optical-impairment-topology' {
+      description
+        "This augment is only valid for optical impairment with sliceable
+         transponder model";
+    }
     description
-      "This augment is only valid for optical impairment with sliceable 
-      transponder model";
-   }
-   description 
-     "Tunnel termination point augmentation for sliceable transponder model.";
-   uses sliceable-transponder-attributes; 
+      "Tunnel termination point augmentation for sliceable transponder model.";
+    uses sliceable-transponder-attributes;
   }
 }


### PR DESCRIPTION
pyang -f yang --keep-comments --ietf --max-line-length 72 ietf-optical-impairment-topology.yang /
-o formatted-ietf-optical-impairment-topology.yang

ietf-optical-impairment-topology.yang:4: warning: line length 75 exceeds 72 characters
ietf-optical-impairment-topology.yang:16: error: module "ietf-te-topology" not found in search path
ietf-optical-impairment-topology.yang:547: warning: line length 110 exceeds 72 characters
ietf-optical-impairment-topology.yang:578: warning: line length 76 exceeds 72 characters
ietf-optical-impairment-topology.yang:611: warning: line length 114 exceeds 72 characters
ietf-optical-impairment-topology.yang:651: warning: line length 78 exceeds 72 characters
ietf-optical-impairment-topology.yang:662: warning: line length 85 exceeds 72 characters
ietf-optical-impairment-topology.yang:689: warning: line length 113 exceeds 72 characters
ietf-optical-impairment-topology.yang:756: warning: line length 80 exceeds 72 characters
ietf-optical-impairment-topology.yang:760: warning: line length 73 exceeds 72 characters
ietf-optical-impairment-topology.yang:761: warning: line length 85 exceeds 72 characters
ietf-optical-impairment-topology.yang:766: warning: line length 104 exceeds 72 characters
ietf-optical-impairment-topology.yang:783: warning: line length 78 exceeds 72 characters
ietf-optical-impairment-topology.yang:787: warning: line length 105 exceeds 72 characters
ietf-optical-impairment-topology.yang:829: warning: line length 75 exceeds 72 characters
ietf-optical-impairment-topology.yang:887: warning: line length 79 exceeds 72 characters
ietf-optical-impairment-topology.yang:934: warning: line length 78 exceeds 72 characters

file is cleaned from trailing spaces, too long lines, lines, bad-whitespace ...

Signed-off-by: EstherLerouzic <esther.lerouzic@orange.com>